### PR TITLE
feat(front): 暗色模式, 中性色收敛为语义主题变量

### DIFF
--- a/gin-blog-front/index.html
+++ b/gin-blog-front/index.html
@@ -19,6 +19,17 @@
   <!-- mathjax -->
   <script src="/js/mathjax.js"></script>
   <script id="Ma thJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
+  <!-- 主题要在首屏渲染前定好, 否则深色模式下会先闪一下白底 -->
+  <script>
+    (function () {
+      try {
+        var saved = localStorage.getItem('blog-theme')
+        var dark = saved ? saved === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches
+        document.documentElement.classList.toggle('dark', dark)
+      } catch (e) { /* localStorage 被禁用时保持默认浅色 */ }
+    })()
+  </script>
 </head>
 
 

--- a/gin-blog-front/src/App.vue
+++ b/gin-blog-front/src/App.vue
@@ -1,9 +1,9 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 
-import BackToTop from '@/components/BackTop.vue'
 import AppHeader from '@/components/layout/AppHeader.vue'
 import GlobalModal from '@/components/modal/index.vue'
+import SideTools from '@/components/SideTools.vue'
 import UToast from '@/components/ui/UToast.vue'
 
 import { useAppStore, useUserStore } from '@/store'
@@ -44,8 +44,8 @@ onMounted(() => {
       </RouterView>
     </article>
   </div>
-  <!-- 回到顶部 -->
-  <BackToTop />
+  <!-- 右下角悬浮工具条: 主题切换 / 回到顶部 -->
+  <SideTools />
   <!-- 全局弹窗 -->
   <GlobalModal />
 </template>

--- a/gin-blog-front/src/components/SideTools.vue
+++ b/gin-blog-front/src/components/SideTools.vue
@@ -1,7 +1,10 @@
 <script setup>
 import { Icon } from '@iconify/vue'
 import { useWindowScroll, watchThrottled } from '@vueuse/core'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { useAppStore } from '@/store'
+
+const appStore = useAppStore()
 
 const { y } = useWindowScroll()
 const styleVal = ref('')
@@ -9,10 +12,10 @@ watchThrottled(y, () => {
   styleVal.value = (y.value > 20) ? 'opacity: 1; transform: translateX(-40px);' : ''
 }, { throttle: 100 })
 
-const options = [
+const options = computed(() => [
   {
-    icon: 'bi:moon-stars-fill',
-    fn: () => window.$message?.info('黑夜模式开发中...'),
+    icon: appStore.isDark ? 'bi:sun-fill' : 'bi:moon-stars-fill',
+    fn: () => appStore.toggleTheme(),
   },
   {
     icon: 'uiw:setting',
@@ -22,7 +25,7 @@ const options = [
     icon: 'fluent:arrow-up-12-filled',
     fn: () => window.scrollTo({ behavior: 'smooth', top: 0 }),
   },
-]
+])
 </script>
 
 <template>

--- a/gin-blog-front/src/components/comment/Comment.vue
+++ b/gin-blog-front/src/components/comment/Comment.vue
@@ -202,7 +202,7 @@ const isLike = computed(() => id => userStore.commentLikeSet.includes(id))
           </div>
           <!-- 楼层 + 时间 + 点赞 + 回复按钮 -->
           <div class="flex justify-between text-sm">
-            <div class="flex items-center gap-2 py-1 color-#b3b3b3">
+            <div class="flex items-center gap-2 py-1 color-muted">
               <span> {{ commentCount - idx }}楼 </span>
               <span> {{ dayjs(comment.created_at).format('YYYY-MM-DD') }} </span>
               <button
@@ -238,7 +238,7 @@ const isLike = computed(() => id => userStore.commentLikeSet.includes(id))
               </div>
               <!-- 时间 + 点赞 + 回复按钮 -->
               <div class="flex justify-between text-sm">
-                <div class="flex items-center gap-2 py-1 color-#b3b3b3">
+                <div class="flex items-center gap-2 py-1 color-muted">
                   <span> {{ dayjs(reply.created_at).format('YYYY-MM-DD') }} </span>
                   <button
                     class="i-mdi:thumb-up hover-bg-red"
@@ -272,7 +272,7 @@ const isLike = computed(() => id => userStore.commentLikeSet.includes(id))
           <div
             v-show="comment.reply_count > 3"
             ref="checkRefs"
-            class="mt-4 text-[13px] color-#6d757a"
+            class="mt-4 text-[13px] color-muted"
           >
             共 <b> {{ comment.reply_count }} </b>  条回复
             <button class="color-#00a1d6" @click="checkReplies(idx, comment)">

--- a/gin-blog-front/src/components/layout/AppHeader.vue
+++ b/gin-blog-front/src/components/layout/AppHeader.vue
@@ -72,6 +72,9 @@ async function logout() {
       </RouterLink>
       <!-- 右上角图标 -->
       <div class="flex items-center gap-2 text-2xl">
+        <button :title="appStore.isDark ? '切换浅色模式' : '切换深色模式'" @click="appStore.toggleTheme()">
+          <Icon :icon="appStore.isDark ? 'mdi:weather-sunny' : 'mdi:weather-night'" />
+        </button>
         <button @click="appStore.setSearchFlag(true)">
           <Icon icon="ic:round-search" />
         </button>
@@ -123,6 +126,12 @@ async function logout() {
               </ul>
             </div>
           </div>
+          <!-- 主题切换 -->
+          <div class="menus-item">
+            <a class="menu-btn flex items-center" :title="appStore.isDark ? '切换浅色模式' : '切换深色模式'" @click="appStore.toggleTheme()">
+              <Icon :icon="appStore.isDark ? 'mdi:weather-sunny' : 'mdi:weather-night'" class="text-xl" />
+            </a>
+          </div>
           <!-- 登录 -->
           <div class="menus-item">
             <a v-if="!userStore.userId" class="menu-btn" @click="appStore.setLoginFlag(true)">
@@ -170,6 +179,13 @@ async function logout() {
   }
 }
 
+/* 滚动后导航栏是实底的, 深色模式下要跟着变暗, 否则一片白 */
+html.dark .nav-fixed {
+  color: var(--c-text);
+  background: rgba(24, 26, 31, 0.85) !important;
+  box-shadow: 0 5px 6px -5px rgba(0, 0, 0, 0.8);
+}
+
 .menus-item {
   position: relative;
   display: inline-block;
@@ -207,7 +223,7 @@ async function logout() {
   width: max-content;
   margin-top: 8px;
   box-shadow: 0 5px 20px -4px rgba(0, 0, 0, 0.5);
-  background-color: #fff;
+  background-color: var(--c-surface);
   animation: submenu 0.3s 0.1s ease both;
 
   &::before {
@@ -220,13 +236,14 @@ async function logout() {
   }
   a {
     line-height: 2;
-    color: #4c4948 !important;
+    color: var(--c-text) !important;
     text-shadow: none;
     display: block;
     padding: 6px 14px;
   }
   a:hover {
     background: #4ab1f4;
+    color: #fff !important;
   }
 }
 

--- a/gin-blog-front/src/components/layout/MobileSideBar.vue
+++ b/gin-blog-front/src/components/layout/MobileSideBar.vue
@@ -65,7 +65,7 @@ async function logout() {
         </div>
       </div>
       <!-- 分隔线 -->
-      <hr class="my-4 border-2 border-color-#d2ebfd border-dashed">
+      <hr class="my-4 border-2 border-color-divider border-dashed">
       <!-- 菜单 -->
       <div v-for="item of menuOptions" :key="item.text" class="m-2 p-1">
         <RouterLink :to="item.path" class="flex items-center" @click="appStore.setCollapsed(false)">

--- a/gin-blog-front/src/components/modal/LoginModal.vue
+++ b/gin-blog-front/src/components/modal/LoginModal.vue
@@ -78,14 +78,14 @@ function openForget() {
           <span class="mr-4 inline-block w-16 text-right"> 用户名 </span>
           <input
             v-model="form.username" required placeholder="用户名"
-            class="block w-full border-0 rounded-md p-2 text-gray-900 shadow-sm outline-none ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-emerald"
+            class="block w-full border-0 rounded-md p-2 text-main shadow-sm outline-none ring-1 ring-line ring-inset placeholder:text-muted focus:ring-2 focus:ring-emerald"
           >
         </div>
         <div class="flex items-center">
           <span class="mr-4 inline-block w-16 text-right"> 密码 </span>
           <input
             v-model="form.password" type="password" placeholder="密码"
-            class="block w-full border-0 rounded-md p-2 text-gray-900 shadow-sm outline-none ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-emerald"
+            class="block w-full border-0 rounded-md p-2 text-main shadow-sm outline-none ring-1 ring-line ring-inset placeholder:text-muted focus:ring-2 focus:ring-emerald"
           >
         </div>
       </div>

--- a/gin-blog-front/src/components/modal/RegisterModal.vue
+++ b/gin-blog-front/src/components/modal/RegisterModal.vue
@@ -56,14 +56,14 @@ function openLogin() {
           <span class="mr-4 inline-block w-16 text-right"> 邮箱 </span>
           <input
             v-model="form.email" required placeholder="请输入邮箱地址"
-            class="block w-full border-0 rounded-md p-2 text-gray-900 shadow-sm outline-none ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-emerald"
+            class="block w-full border-0 rounded-md p-2 text-main shadow-sm outline-none ring-1 ring-line ring-inset placeholder:text-muted focus:ring-2 focus:ring-emerald"
           >
         </div>
         <div class="flex items-center">
           <span class="mr-4 inline-block w-16 text-right"> 密码 </span>
           <input
             v-model="form.password" required type="password" placeholder="请输入密码"
-            class="block w-full border-0 rounded-md p-2 text-gray-900 shadow-sm outline-none ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-emerald"
+            class="block w-full border-0 rounded-md p-2 text-main shadow-sm outline-none ring-1 ring-line ring-inset placeholder:text-muted focus:ring-2 focus:ring-emerald"
           >
         </div>
       </div>

--- a/gin-blog-front/src/components/modal/SearchModal.vue
+++ b/gin-blog-front/src/components/modal/SearchModal.vue
@@ -44,11 +44,11 @@ async function handleSearch() {
           </div>
           <input
             v-model="keyword"
-            class="block w-full border-0 rounded-full py-2 pl-8 pr-5 text-gray-900 outline-none ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-green-300"
+            class="block w-full border-0 rounded-full py-2 pl-8 pr-5 text-main outline-none ring-1 ring-line ring-inset placeholder:text-muted focus:ring-2 focus:ring-green-300"
             placeholder="输入文章标题或内容..."
           >
         </div>
-        <hr class="my-4 border-1.5 border-color-#d2ebfd border-dashed">
+        <hr class="my-4 border-1.5 border-color-divider border-dashed">
         <div class="h-[420px] overflow-y-auto">
           <ul v-if="articleList.length">
             <li v-for="item of articleList" :key="item.id" class="text-sm">
@@ -56,9 +56,9 @@ async function handleSearch() {
                 <span class="border-b-1 border-#999 border-solid text-lg" @click="searchFlag = false" v-html="item.title" />
               </RouterLink>
               <div class="ell-4 mt-1">
-                <p clsas="color-#555 cursor-pointer" v-html="item.content" />
+                <p clsas="color-muted cursor-pointer" v-html="item.content" />
               </div>
-              <hr class="my-3 border-1 border-#d2ebfd border-dashed">
+              <hr class="my-3 border-1 border-divider border-dashed">
             </li>
           </ul>
           <div v-else-if="keyword">

--- a/gin-blog-front/src/components/ui/UDrawer.vue
+++ b/gin-blog-front/src/components/ui/UDrawer.vue
@@ -65,7 +65,7 @@ const styleObject = computed(() => {
     </div>
     <div
       v-bind="$attrs"
-      class="fixed z-35 overflow-y-auto bg-white transition-all duration-200"
+      class="fixed z-35 overflow-y-auto bg-surface transition-all duration-200"
       :class="[`duration-${duration}`, {
         '-left-full top-0': placement === 'left' && !modelValue,
         'left-0 top-0': placement === 'left' && modelValue,

--- a/gin-blog-front/src/components/ui/UModal.vue
+++ b/gin-blog-front/src/components/ui/UModal.vue
@@ -69,7 +69,7 @@ function close() {
       <div class="min-h-full flex items-center justify-center p-3">
         <div
           v-bind="$attrs"
-          class="relative inline-block w-full rounded-lg bg-white shadow-xl transition-all dark:bg-gray-900"
+          class="relative inline-block w-full rounded-lg bg-surface shadow-xl transition-all"
           :class="[
             padded ? 'p-4 lg:py-5 lg:px-7' : 'p-1',
             isOpen
@@ -82,7 +82,7 @@ function close() {
         >
           <button
             v-if="dismissButton"
-            class="absolute right-5 top-5 h-6 w-6 rounded-full bg-gray-100 p-1 text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-500"
+            class="absolute right-5 top-5 h-6 w-6 rounded-full bg-surface-soft p-1 text-main hover:bg-line focus:outline-none focus:ring-2 focus:ring-gray-500"
             @click="close"
           >
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke="currentColor">

--- a/gin-blog-front/src/components/ui/UToast.vue
+++ b/gin-blog-front/src/components/ui/UToast.vue
@@ -92,7 +92,7 @@ defineExpose({
           }"
         >
           <slot :type="event.type" :content="event.content">
-            <div class="pointer-events-auto w-full overflow-hidden rounded-lg bg-white ring-1 ring-black ring-opacity-5">
+            <div class="pointer-events-auto w-full overflow-hidden rounded-lg bg-surface ring-1 ring-black ring-opacity-5">
               <div class="flex justify-between px-4 py-3">
                 <div class="flex items-center">
                   <div
@@ -112,7 +112,7 @@ defineExpose({
                 </div>
                 <button
                   v-if="closeable"
-                  class="i-mdi:close h-5 w-5 flex items-center justify-center rounded-full rounded-full p-1 text-gray-400 font-bold hover:text-gray-600"
+                  class="i-mdi:close h-5 w-5 flex items-center justify-center rounded-full rounded-full p-1 text-muted font-bold hover:text-main"
                   @click="flux.remove(event)"
                 />
               </div>

--- a/gin-blog-front/src/main.js
+++ b/gin-blog-front/src/main.js
@@ -4,6 +4,7 @@ import App from './App.vue'
 import { router } from './router'
 
 import { pinia } from './store'
+import { useAppStore } from './store/app'
 import { setupMock } from './utils/http'
 // custom style
 import './styles/index.css'
@@ -21,6 +22,7 @@ async function bootstrap() {
   const app = createApp(App)
   app.use(router)
   app.use(pinia)
+  useAppStore(pinia).initTheme() // index.html 已经加过 class, 这里把 store 状态对齐
   app.mount('#app')
 }
 

--- a/gin-blog-front/src/store/app.js
+++ b/gin-blog-front/src/store/app.js
@@ -2,12 +2,24 @@ import { defineStore } from 'pinia'
 import api from '@/api'
 import { convertImgUrl } from '@/utils'
 
+const THEME_KEY = 'blog-theme'
+
+// 没存过偏好时跟随系统, 存过就以用户的选择为准
+function initialTheme() {
+  const saved = localStorage.getItem(THEME_KEY)
+  if (saved === 'dark' || saved === 'light') {
+    return saved
+  }
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
 export const useAppStore = defineStore('app', {
   state: () => ({
     searchFlag: false,
     loginFlag: false,
     registerFlag: false,
     collapsed: false, // 侧边栏折叠（移动端）
+    theme: 'light', // light | dark, 由 initTheme 校正
 
     page_list: [], // 页面数据
     // TODO: 优化
@@ -33,12 +45,26 @@ export const useAppStore = defineStore('app', {
     viewCount: state => state.blogInfo.view_count ?? 0,
     pageList: state => state.page_list ?? [],
     blogConfig: state => state.blog_config,
+    isDark: state => state.theme === 'dark',
   },
   actions: {
     setCollapsed(flag) { this.collapsed = flag },
     setLoginFlag(flag) { this.loginFlag = flag },
     setRegisterFlag(flag) { this.registerFlag = flag },
     setSearchFlag(flag) { this.searchFlag = flag },
+
+    // 入口处调用一次, 把 store 和 <html> 的 class 对齐
+    initTheme() {
+      this.setTheme(initialTheme())
+    },
+    setTheme(theme) {
+      this.theme = theme === 'dark' ? 'dark' : 'light'
+      localStorage.setItem(THEME_KEY, this.theme)
+      document.documentElement.classList.toggle('dark', this.theme === 'dark')
+    },
+    toggleTheme() {
+      this.setTheme(this.theme === 'dark' ? 'light' : 'dark')
+    },
 
     async getBlogInfo() {
       try {

--- a/gin-blog-front/src/store/app.spec.js
+++ b/gin-blog-front/src/store/app.spec.js
@@ -15,6 +15,8 @@ describe('useAppStore', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
     vi.clearAllMocks()
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
   })
 
   it('弹框开关只改对应字段', () => {
@@ -75,5 +77,53 @@ describe('useAppStore', () => {
     expect(store.pageList[0].cover).toBe('http://test-server/public/uploaded/home.png')
     // 已经是完整 URL 的不动
     expect(store.pageList[1].cover).toBe('https://cdn.com/archive.png')
+  })
+
+  it('toggleTheme 同时改 store、localStorage 和 html 的 class', () => {
+    const store = useAppStore()
+
+    store.toggleTheme()
+    expect(store.theme).toBe('dark')
+    expect(store.isDark).toBe(true)
+    expect(localStorage.getItem('blog-theme')).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+
+    store.toggleTheme()
+    expect(store.theme).toBe('light')
+    expect(localStorage.getItem('blog-theme')).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('initTheme 优先用存过的偏好', () => {
+    localStorage.setItem('blog-theme', 'dark')
+
+    const store = useAppStore()
+    store.initTheme()
+
+    expect(store.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('initTheme 没有偏好时跟随系统', () => {
+    // jsdom 没有实现 matchMedia, 直接塞一个假的
+    const matchMedia = vi.fn().mockReturnValue({ matches: true })
+    vi.stubGlobal('matchMedia', matchMedia)
+
+    const store = useAppStore()
+    store.initTheme()
+
+    expect(matchMedia).toHaveBeenCalledWith('(prefers-color-scheme: dark)')
+    expect(store.theme).toBe('dark')
+    vi.unstubAllGlobals()
+  })
+
+  it('setTheme 遇到非法值回落到浅色', () => {
+    const store = useAppStore()
+
+    store.setTheme('dark')
+    store.setTheme('rainbow')
+
+    expect(store.theme).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
   })
 })

--- a/gin-blog-front/src/styles/common.css
+++ b/gin-blog-front/src/styles/common.css
@@ -6,5 +6,5 @@
 
 /* 卡片面板 */
 .card-view {
-  @apply bg-white p-3 rounded-xl transition-500 hover:shadow-2xl;
+  @apply bg-surface p-3 rounded-xl transition-500 hover:shadow-2xl;
 }

--- a/gin-blog-front/src/styles/index.css
+++ b/gin-blog-front/src/styles/index.css
@@ -4,6 +4,27 @@
 :root {
   font-family: Inter, sans-serif;
   font-feature-settings: 'liga' 1, 'calt' 1; /* fix for Chrome */
+
+  /* 主题色板: 深色模式在 html.dark 下整体覆盖 */
+  color-scheme: light;
+  --c-surface: #fff;
+  --c-surface-soft: #f3f4f6;
+  --c-text: #18181b;
+  --c-text-muted: #6b7280;
+  --c-border: #d1d5db;
+  --c-divider: #d2ebfd;
+  --c-body-bg: linear-gradient(90deg, rgba(247, 149, 51, 0.1) 0, rgba(243, 112, 85, 0.1) 15%, rgba(239, 78, 123, 0.1) 30%, rgba(161, 102, 171, 0.1) 44%, rgba(80, 115, 184, 0.1) 58%, rgba(16, 152, 173, 0.1) 72%, rgba(7, 179, 155, 0.1) 86%, rgba(109, 186, 130, 0.1) 100%);
+}
+
+html.dark {
+  color-scheme: dark;
+  --c-surface: #23272e;
+  --c-surface-soft: #2f343c;
+  --c-text: #d6dae0;
+  --c-text-muted: #8b939f;
+  --c-border: #3d434c;
+  --c-divider: #363c45;
+  --c-body-bg: linear-gradient(90deg, #16181d 0, #1b1e24 50%, #16181d 100%);
 }
 
 @supports (font-variation-settings: normal) {
@@ -24,7 +45,9 @@ body {
   width: 100%;
   height: 100%;
   overflow-y: scroll;
-  background: linear-gradient(90deg, rgba(247, 149, 51, 0.1) 0, rgba(243, 112, 85, 0.1) 15%, rgba(239, 78, 123, 0.1) 30%, rgba(161, 102, 171, 0.1) 44%, rgba(80, 115, 184, 0.1) 58%, rgba(16, 152, 173, 0.1) 72%, rgba(7, 179, 155, 0.1) 86%, rgba(109, 186, 130, 0.1) 100%);
+  color: var(--c-text);
+  background: var(--c-body-bg);
+  transition: background 0.3s, color 0.3s;
 
   /* font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Lato, Roboto, "PingFang SC", "Microsoft YaHei", sans-serif !important; */
 

--- a/gin-blog-front/src/views/about/index.vue
+++ b/gin-blog-front/src/views/about/index.vue
@@ -38,7 +38,7 @@ onMounted(async () => {
       <img :src="blogConfig.website_avatar" class="w-25 duration-600 hover:rotate-360" alt="avatar">
     </div>
     <div class="flex justify-center">
-      <article class="max-w-none prose prose-truegray">
+      <article class="max-w-none prose prose-truegray dark:prose-invert">
         <div v-html="html" />
       </article>
     </div>

--- a/gin-blog-front/src/views/article/detail/components/Catalogue.vue
+++ b/gin-blog-front/src/views/article/detail/components/Catalogue.vue
@@ -64,7 +64,7 @@ watchThrottled(y, () => {
       <ul>
         <li v-for="anchor of anchors" :key="anchor.id">
           <div
-            class="cursor-pointer border-l-4 border-transparent rounded py-1 text-sm color-#666261 hover:bg-#00c4b6 hover:bg-opacity-30"
+            class="cursor-pointer border-l-4 border-transparent rounded py-1 text-sm color-muted hover:bg-#00c4b6 hover:bg-opacity-30"
             :class="anchor.id === selectAnchor && 'bg-#00c4b6 text-white border-l-#009d92'"
             :style="{ paddingLeft: `${5 + anchor.indent * 15}px` }" @click="handleClickAnchor(anchor.id)"
           >

--- a/gin-blog-front/src/views/article/detail/components/Copyright.vue
+++ b/gin-blog-front/src/views/article/detail/components/Copyright.vue
@@ -10,15 +10,15 @@ const articleHref = window.location.href
   <div class="border-1 border-lightblue border-dashed px-4 py-3 leading-7">
     <!-- TODO: 点击复制 -->
     <div class="relative">
-      <div class="absolute right-0 top-0 h-5 w-5 border-4px border-blue rounded-full bg-white" />
+      <div class="absolute right-0 top-0 h-5 w-5 border-4px border-blue rounded-full bg-surface" />
       <span class="color-#49b1f5 font-bold"> 文章作者： </span>
-      <RouterLink to="/" class="color-#99a9bf !underline">
+      <RouterLink to="/" class="color-muted !underline">
         {{ blogConfig.website_author }}
       </RouterLink>
     </div>
     <div>
       <span class="color-#49b1f5 font-bold"> 文章链接： </span>
-      <a :href="articleHref" class="color-#99a9bf !underline">
+      <a :href="articleHref" class="color-muted !underline">
         {{ articleHref }}
       </a>
     </div>
@@ -28,7 +28,7 @@ const articleHref = window.location.href
         本博客所有文章除特别声明外，均采用
         <a
           href="https://creativecommons.org/licenses/by-nc-sa/4.0/" target="_blank"
-          class="color-#99a9bf !underline"
+          class="color-muted !underline"
         >
           CC BY-NC-SA 4.0
         </a>

--- a/gin-blog-front/src/views/article/detail/components/LatestList.vue
+++ b/gin-blog-front/src/views/article/detail/components/LatestList.vue
@@ -15,7 +15,7 @@ const { articleList } = defineProps({
         <span class="ml-2"> 最新文章 </span>
       </div>
       <ul class="space-y-1">
-        <li v-for="item of articleList" :key="item.title" class="p-1 hover:bg-gray-200">
+        <li v-for="item of articleList" :key="item.title" class="p-1 hover:bg-surface-soft">
           <RouterLink :to="`/article/${item.id}`" class="border-b-1 border-dashed last:border-none">
             <div class="flex items-center">
               <img :src="convertImgUrl(item.img)" class="h-15 w-15 overflow-hidden">

--- a/gin-blog-front/src/views/article/detail/index.vue
+++ b/gin-blog-front/src/views/article/detail/index.vue
@@ -93,7 +93,7 @@ const styleVal = computed(() =>
         <!-- 文章内容 -->
         <article
           ref="previewRef"
-          class="max-w-none prose prose-truegray lg:mx-10"
+          class="max-w-none prose prose-truegray lg:mx-10 dark:prose-invert"
           v-html="data.content"
         />
         <!-- 版权声明 -->
@@ -118,7 +118,7 @@ const styleVal = computed(() =>
           class="mt-7 lg:mx-5"
         />
         <!-- 分隔线 -->
-        <hr class="my-10 border-2 border-color-#d2ebfd border-dashed lg:mx-5">
+        <hr class="my-10 border-2 border-color-divider border-dashed lg:mx-5">
         <!-- 文章评论 -->
         <Comment :type="1" class="lg:mx-5" />
       </div>

--- a/gin-blog-front/src/views/article/list/index.vue
+++ b/gin-blog-front/src/views/article/list/index.vue
@@ -28,7 +28,7 @@ onMounted(async () => {
     <div class="grid grid-cols-12 gap-4">
       <div v-for="article of articleList" :key="article.id" class="col-span-12 lg:col-span-4 md:col-span-6">
         <!-- 卡片 -->
-        <div class="animate-zoom-in animate-duration-650 rounded-xl bg-white pb-2 shadow-md transition-300 hover:shadow-2xl">
+        <div class="animate-zoom-in animate-duration-650 rounded-xl bg-surface pb-2 shadow-md transition-300 hover:shadow-2xl">
           <!-- 图片 -->
           <div class="overflow-hidden">
             <RouterLink :to="`/article/${article.id}`">
@@ -52,7 +52,7 @@ onMounted(async () => {
                 </span>
                 <!-- 分类 -->
                 <RouterLink :to="`/categories/${article.category_id}?name=${article.category?.name}`">
-                  <div class="flex items-center text-#4c4948 transition-300 hover:color-violet">
+                  <div class="flex items-center text-main transition-300 hover:color-violet">
                     <span class="i-ic:outline-bookmark mr-1" />
                     <span> {{ article.category?.name }} </span>
                   </div>
@@ -60,7 +60,7 @@ onMounted(async () => {
               </div>
             </div>
             <!-- divider -->
-            <div class="my-2 h-0.5 bg-gray-200" />
+            <div class="my-2 h-0.5 bg-surface-soft" />
             <!-- 标签 -->
             <div class="px-3 space-x-1.5">
               <RouterLink v-for="tag of article.tags" :key="tag.id" :to="`/tags/${tag.id}?name=${tag.name}`">

--- a/gin-blog-front/src/views/discover/archive/index.vue
+++ b/gin-blog-front/src/views/discover/archive/index.vue
@@ -58,14 +58,14 @@ onMounted(() => {
     <template v-for="(item, idx) of archiveList" :key="item.id">
       <div class="flex items-center gap-2">
         <div class="i-mdi:circle bg-blue text-sm" />
-        <span class="text-sm color-#666 lg:text-base">
+        <span class="text-sm color-muted lg:text-base">
           {{ dayjs(item.created_at).format('YYYY-MM-DD') }}
         </span>
-        <a class="color-#666 lg:text-lg hover:text-orange" @click="router.push(`/article/${item.id}`)">
+        <a class="color-muted lg:text-lg hover:text-orange" @click="router.push(`/article/${item.id}`)">
           {{ item.title }}
         </a>
       </div>
-      <hr v-if="idx !== archiveList.length - 1" class="my-4 border-1 border-color-#d2ebfd border-dashed">
+      <hr v-if="idx !== archiveList.length - 1" class="my-4 border-1 border-color-divider border-dashed">
     </template>
 
     <!-- TODO: 分页 -->

--- a/gin-blog-front/src/views/home/components/ArticleCard.vue
+++ b/gin-blog-front/src/views/home/components/ArticleCard.vue
@@ -16,7 +16,7 @@ const isRightClass = computed(() => props.idx % 2 === 0
 </script>
 
 <template>
-  <div class="group h-[430px] w-full flex flex-col animate-zoom-in animate-duration-700 items-center rounded-xl bg-white shadow-md transition-600 md:h-[280px] md:flex-row hover:shadow-2xl">
+  <div class="group h-[430px] w-full flex flex-col animate-zoom-in animate-duration-700 items-center rounded-xl bg-surface shadow-md transition-600 md:h-[280px] md:flex-row hover:shadow-2xl">
     <!-- 封面图 -->
     <div :class="isRightClass" class="h-[230px] w-full overflow-hidden md:h-full md:w-45/100">
       <RouterLink :to="`/article/${article.id}`">
@@ -30,7 +30,7 @@ const isRightClass = computed(() => props.idx % 2 === 0
           {{ article.title }}
         </span>
       </RouterLink>
-      <div class="flex flex-wrap text-sm color-[#858585]">
+      <div class="flex flex-wrap text-sm color-muted">
         <!-- 置顶 -->
         <span v-if="article.is_top === 1" class="flex items-center color-[#ff7242]">
           <span class="i-carbon:align-vertical-top mr-1" /> 置顶

--- a/gin-blog-front/src/views/link/components/AddLink.vue
+++ b/gin-blog-front/src/views/link/components/AddLink.vue
@@ -2,10 +2,10 @@
   <div class="space-y-5">
     <p class="flex items-center text-xl">
       <span class="i-mdi:link-variant-plus mr-4 text-blue" />
-      <span class="color-#344c67 font-bold"> 申请友链 </span>
+      <span class="color-main font-bold"> 申请友链 </span>
     </p>
     <!-- 添加友链格式 -->
-    <blockquote class="border-l-3 border-color-#49b1f5 rounded-l-5 bg-#ecf7fe px-4 py-3 leading-7">
+    <blockquote class="border-l-3 border-color-#49b1f5 rounded-l-5 bg-#ecf7fe px-4 py-3 leading-7 dark:bg-#1d2a33">
       <p>名称：阵、雨的个人博客</p>
       <p>简介：往事随风而去</p>
       <p>头像：https://foruda.gitee.com/avatar/1677041571085433939/5221991_szluyu99_1614389421.png</p>
@@ -13,7 +13,7 @@
     <p>
       需要交换友链的在下方留言💖:
     </p>
-    <blockquote class="border-l-3 border-color-#49b1f5 rounded-l-5 bg-#ecf7fe px-4 py-3 leading-7">
+    <blockquote class="border-l-3 border-color-#49b1f5 rounded-l-5 bg-#ecf7fe px-4 py-3 leading-7 dark:bg-#1d2a33">
       友链信息展示需要，您的信息格式要包含：名称、介绍、链接、头像
     </blockquote>
   </div>

--- a/gin-blog-front/src/views/link/components/LinkList.vue
+++ b/gin-blog-front/src/views/link/components/LinkList.vue
@@ -14,7 +14,7 @@ defineProps({
     <!-- 标题 -->
     <p class="flex items-center text-xl">
       <span class="i-mdi:link-variant mr-4 text-blue" />
-      <span class="color-#344c67 font-bold"> 友情链接 </span>
+      <span class="color-main font-bold"> 友情链接 </span>
     </p>
     <!-- 链接列表 -->
     <!-- 友链数量不为 0 -->

--- a/gin-blog-front/src/views/user/UploadOne.vue
+++ b/gin-blog-front/src/views/user/UploadOne.vue
@@ -51,8 +51,8 @@ async function handleFileChange() {
 
 <template>
   <!-- TODO: 拖拽文件上传 -->
-  <main class="flex items-center justify-center bg-gray-100 font-sans">
-    <label for="dropzone-file" class="mx-auto max-w-[300px] w-full cursor-pointer items-center border-1 border-blue-400 rounded-xl border-dashed bg-white p-2 text-center">
+  <main class="flex items-center justify-center bg-surface-soft font-sans">
+    <label for="dropzone-file" class="mx-auto max-w-[300px] w-full cursor-pointer items-center border-1 border-blue-400 rounded-xl border-dashed bg-surface p-2 text-center">
       <template v-if="previewImg">
         <div class="group relative">
           <img class="lg:h-[160px] lg:w-[160px]" :src="imgUrl" alt="user avatar">

--- a/gin-blog-front/src/views/user/index.vue
+++ b/gin-blog-front/src/views/user/index.vue
@@ -62,7 +62,7 @@ async function updateUserInfo() {
             </div>
             <input
               v-model="form[item.key]" required :placeholder="`请输入${item.label}`"
-              class="block w-full border-0 rounded-md p-2 text-gray-900 shadow-sm outline-none ring-1 ring-gray-300 ring-inset placeholder:text-gray-400 focus:ring-2 focus:ring-emerald"
+              class="block w-full border-0 rounded-md p-2 text-main shadow-sm outline-none ring-1 ring-line ring-inset placeholder:text-muted focus:ring-2 focus:ring-emerald"
             >
           </div>
         </div>

--- a/gin-blog-front/uno.config.js
+++ b/gin-blog-front/uno.config.js
@@ -40,6 +40,19 @@ export default defineConfig({
   shortcuts: [
     ['f-c-c', 'flex justify-center items-center'],
   ],
+  // 语义色都指向 CSS 变量, 变量在 styles/index.css 里按 html.dark 切换,
+  // 这样切主题只改根元素 class, 不用给每个类名都写一遍 dark: 变体
+  theme: {
+    colors: {
+      'primary': '#49b1f5',
+      'surface': 'var(--c-surface)',
+      'surface-soft': 'var(--c-surface-soft)',
+      'main': 'var(--c-text)',
+      'muted': 'var(--c-text-muted)',
+      'line': 'var(--c-border)',
+      'divider': 'var(--c-divider)',
+    },
+  },
   presets: [
     presetUno(),
     presetIcons({ warn: true, collections: iconCollections }),


### PR DESCRIPTION
Change-Id: I07ba160fda83a2b34a2b733d58b60fc26d8ffb51

## 改动
- uno.config.js 新增语义色 surface / surface-soft / main / muted / line / divider，全部指向 CSS 变量
- styles/index.css 提供 :root 与 html.dark 两套变量（含 color-scheme、深色 body 渐变）
- store/app.js 新增 theme 状态与 initTheme/setTheme/toggleTheme，偏好存 localStorage，无偏好时跟随 prefers-color-scheme
- index.html 首屏前内联脚本先打 dark class，避免闪白底
- 开关位置：顶部导航栏（桌面 + 移动）与右下角悬浮工具条；原 BackTop.vue 里"黑夜模式开发中"的占位改成真实切换，文件重命名为 SideTools.vue
- 约 20 个组件/页面的硬编码中性色替换为语义色，文章与关于页 prose 加 dark:prose-invert

## 验证
- pnpm test 24 passed（新增 4 条主题用例：切换、跟随系统、已存偏好优先、非法值回落）
- pnpm lint / pnpm build 通过，产物 CSS 中已确认生成 .bg-surface、.dark .dark\:prose-invert 等规则
- 未做浏览器实景截图验证（本机装不上无头浏览器），深色调色板取值待 review 时按观感调整
