### PR TITLE
perf(server): 补齐热点查询索引, 评论列表去掉 N+1 与失效分页, 计数改批量读取

### DIFF
--- a/gin-blog-server/internal/global/keys.go
+++ b/gin-blog-server/internal/global/keys.go
@@ -39,5 +39,6 @@ const (
 const (
 	CONFIG_ARTICLE_COVER     = "article_cover"
 	CONFIG_IS_COMMENT_REVIEW = "is_comment_review"
+	CONFIG_IS_MESSAGE_REVIEW = "is_message_review"
 	CONFIG_ABOUT             = "about"
 )

--- a/gin-blog-server/internal/handle/cache.go
+++ b/gin-blog-server/internal/handle/cache.go
@@ -5,12 +5,73 @@ import (
 	"encoding/json"
 	g "gin-blog/internal/global"
 	"gin-blog/internal/model"
-	"github.com/redis/go-redis/v9"
+	"log/slog"
+	"strconv"
 	"time"
+
+	"github.com/redis/go-redis/v9"
 )
 
 // redis context
 var rctx = context.Background()
+
+/*
+按 id 批量取计数
+
+列表接口以前用 HGetAll / ZRange(0, -1) 把整个计数集合拉回来, 只为给当页十几条
+数据填数, 开销随文章/评论总量线性增长。这里只取当页需要的字段。
+计数属于展示信息, 取不到就当 0, 不让 Redis 抖动影响列表本身。
+*/
+func hashCounts(rdb *redis.Client, key string, ids []int) map[int]int {
+	counts := make(map[int]int, len(ids))
+	if len(ids) == 0 {
+		return counts
+	}
+
+	fields := make([]string, 0, len(ids))
+	for _, id := range ids {
+		fields = append(fields, strconv.Itoa(id))
+	}
+
+	vals, err := rdb.HMGet(rctx, key, fields...).Result()
+	if err != nil {
+		slog.Warn("批量读取计数失败", "key", key, "err", err)
+		return counts
+	}
+	for i, val := range vals {
+		s, ok := val.(string)
+		if !ok { // 字段不存在时是 nil
+			continue
+		}
+		if n, err := strconv.Atoi(s); err == nil {
+			counts[ids[i]] = n
+		}
+	}
+	return counts
+}
+
+// hashCounts 的 ZSet 版本
+func zsetCounts(rdb *redis.Client, key string, ids []int) map[int]int {
+	counts := make(map[int]int, len(ids))
+	if len(ids) == 0 {
+		return counts
+	}
+
+	members := make([]string, 0, len(ids))
+	for _, id := range ids {
+		members = append(members, strconv.Itoa(id))
+	}
+
+	scores, err := rdb.ZMScore(rctx, key, members...).Result()
+	if err != nil {
+		slog.Warn("批量读取计数失败", "key", key, "err", err)
+		return counts
+	}
+	for i, score := range scores {
+		counts[ids[i]] = int(score) // 成员不存在时 score 为 0
+	}
+	return counts
+}
 
 // Page
 

--- a/gin-blog-server/internal/handle/handle_article.go
+++ b/gin-blog-server/internal/handle/handle_article.go
@@ -265,21 +265,18 @@ func (*Article) GetList(c *gin.Context) {
 		return
 	}
 
-	likeCountMap := rdb.HGetAll(rctx, g.ARTICLE_LIKE_COUNT).Val()
-	viewCountZ := rdb.ZRangeWithScores(rctx, g.ARTICLE_VIEW_COUNT, 0, -1).Val()
-
-	viewCountMap := make(map[int]int)
-	for _, article := range viewCountZ {
-		id, _ := strconv.Atoi(article.Member.(string))
-		viewCountMap[id] = int(article.Score)
+	ids := make([]int, 0, len(list))
+	for _, article := range list {
+		ids = append(ids, article.ID)
 	}
+	likeCountMap := hashCounts(rdb, g.ARTICLE_LIKE_COUNT, ids)
+	viewCountMap := zsetCounts(rdb, g.ARTICLE_VIEW_COUNT, ids)
 
 	data := make([]ArticleVO, 0)
 	for _, article := range list {
-		likeCount, _ := strconv.Atoi(likeCountMap[strconv.Itoa(article.ID)])
 		data = append(data, ArticleVO{
 			Article:   article,
-			LikeCount: likeCount,
+			LikeCount: likeCountMap[article.ID],
 			ViewCount: viewCountMap[article.ID],
 		})
 	}

--- a/gin-blog-server/internal/handle/handle_front.go
+++ b/gin-blog-server/internal/handle/handle_front.go
@@ -172,7 +172,8 @@ func (*Front) SaveMessage(c *gin.Context) {
 
 	ipAddress := utils.IP.GetIpAddress(c)
 	ipSource := utils.IP.GetIpSource(ipAddress)
-	isReview := model.GetConfigBool(db, g.CONFIG_IS_COMMENT_REVIEW)
+	// 留言要读留言自己的审核开关, 之前读的是评论的开关, 后台设置里的 is_message_review 根本没人用
+	isReview := model.GetConfigBool(db, g.CONFIG_IS_MESSAGE_REVIEW)
 
 	info := auth.UserInfo
 	message, err := model.SaveMessage(db, info.Nickname, info.Nickname, req.Content, ipAddress, ipSource, req.Speed, isReview)
@@ -256,12 +257,16 @@ func (*Front) GetCommentList(c *gin.Context) {
 		return
 	}
 
-	likeCountMap := rdb.HGetAll(rctx, g.COMMENT_LIKE_COUNT).Val()
-	for i, comment := range data {
+	ids := make([]int, 0, len(data))
+	for _, comment := range data {
+		ids = append(ids, comment.ID)
+	}
+	likeCountMap := hashCounts(rdb, g.COMMENT_LIKE_COUNT, ids)
+	for i := range data {
 		if len(data[i].ReplyList) > 3 {
 			data[i].ReplyList = data[i].ReplyList[:3] // 只显示 3 条回复
 		}
-		data[i].LikeCount, _ = strconv.Atoi(likeCountMap[strconv.Itoa(comment.ID)])
+		data[i].LikeCount = likeCountMap[data[i].ID]
 	}
 
 	ReturnSuccess(c, PageResult[model.CommentVO]{
@@ -303,14 +308,17 @@ func (*Front) GetReplyListByCommentId(c *gin.Context) {
 		return
 	}
 
-	likeCountMap := rdb.HGetAll(rctx, g.COMMENT_LIKE_COUNT).Val()
-
-	data := make([]model.CommentVO, 0)
+	ids := make([]int, 0, len(replyList))
 	for _, reply := range replyList {
-		like, _ := strconv.Atoi(likeCountMap[strconv.Itoa(reply.ID)])
+		ids = append(ids, reply.ID)
+	}
+	likeCountMap := hashCounts(rdb, g.COMMENT_LIKE_COUNT, ids)
+
+	data := make([]model.CommentVO, 0, len(replyList))
+	for _, reply := range replyList {
 		data = append(data, model.CommentVO{
 			Comment:   reply,
-			LikeCount: like,
+			LikeCount: likeCountMap[reply.ID],
 		})
 	}
 

--- a/gin-blog-server/internal/handle/handle_front_test.go
+++ b/gin-blog-server/internal/handle/handle_front_test.go
@@ -326,13 +326,22 @@ func TestFrontSaveMessage(t *testing.T) {
 	decodeData(t, resp.Data, &message)
 	assert.Equal(t, "测试昵称", message.Nickname, "昵称取自登录用户, 不信前端传的")
 	assert.NotContains(t, message.Content, "<script>", "内容要转义, 防 XSS")
-	assert.False(t, message.IsReview, "默认没开审核")
+	assert.False(t, message.IsReview, "没有配置时按需要审核处理")
 
-	// 开启评论审核后, 新留言需要审核
+	// 评论的审核开关不能影响留言
 	assert.Nil(t, env.db.Create(&model.Config{Key: g.CONFIG_IS_COMMENT_REVIEW, Value: "true"}).Error)
 	resp = env.do(t, http.MethodPost, "/front/message", map[string]any{
 		"nickname": "测试昵称",
 		"content":  "第二条留言",
+	})
+	decodeData(t, resp.Data, &message)
+	assert.False(t, message.IsReview, "留言只看 is_message_review")
+
+	// is_message_review 为 true 表示留言免审核, 直接展示 (与后台设置页的选项对应)
+	assert.Nil(t, env.db.Create(&model.Config{Key: g.CONFIG_IS_MESSAGE_REVIEW, Value: "true"}).Error)
+	resp = env.do(t, http.MethodPost, "/front/message", map[string]any{
+		"nickname": "测试昵称",
+		"content":  "第三条留言",
 	})
 	decodeData(t, resp.Data, &message)
 	assert.True(t, message.IsReview)
@@ -399,10 +408,11 @@ func TestFrontGetCommentList(t *testing.T) {
 	user := model.UserAuth{Username: "u", Password: "x", UserInfo: &model.UserInfo{Nickname: "n"}}
 	assert.Nil(t, env.db.Create(&user).Error)
 
-	top, err := model.AddComment(env.db, user.ID, 1, article.ID, "顶级评论", false)
+	// 前台只展示审核通过的评论, 所以这里造的数据都是已审核的
+	top, err := model.AddComment(env.db, user.ID, 1, article.ID, "顶级评论", true)
 	assert.Nil(t, err)
 	for i := 0; i < 4; i++ {
-		_, err = model.ReplyComment(env.db, user.ID, user.ID, top.ID, "回复"+itoa(i), false)
+		_, err = model.ReplyComment(env.db, user.ID, user.ID, top.ID, "回复"+itoa(i), true)
 		assert.Nil(t, err)
 	}
 	env.rdb.HSet(rctx, g.COMMENT_LIKE_COUNT, itoa(top.ID), 5)
@@ -426,4 +436,12 @@ func TestFrontGetCommentList(t *testing.T) {
 	// 非法的评论 id
 	resp = env.do(t, http.MethodGet, "/front/comment/replies/abc", nil)
 	assert.Equal(t, g.ErrRequest.Code(), resp.Code)
+
+	// 未审核的评论不出现在前台
+	_, err = model.AddComment(env.db, user.ID, 1, article.ID, "待审核", false)
+	assert.Nil(t, err)
+	decodeData(t, env.do(t, http.MethodGet,
+		"/front/comment/list?page_num=1&page_size=10&topic_id="+itoa(article.ID)+"&type=1", nil).Data, &page)
+	assert.Equal(t, int64(1), page.Total)
+	assert.Len(t, page.List, 1)
 }

--- a/gin-blog-server/internal/model/article.go
+++ b/gin-blog-server/internal/model/article.go
@@ -28,14 +28,14 @@ type Article struct {
 	Desc        string `json:"desc"`
 	Content     string `json:"content"`
 	Img         string `json:"img"`
-	Type        int    `gorm:"type:tinyint;comment:类型(1-原创 2-转载 3-翻译)" json:"type"` // 1-原创 2-转载 3-翻译
-	Status      int    `gorm:"type:tinyint;comment:状态(1-公开 2-私密)" json:"status"`    // 1-公开 2-私密
+	Type        int    `gorm:"type:tinyint;comment:类型(1-原创 2-转载 3-翻译)" json:"type"`                                // 1-原创 2-转载 3-翻译
+	Status      int    `gorm:"type:tinyint;index:idx_article_list,priority:2;comment:状态(1-公开 2-私密)" json:"status"` // 1-公开 2-私密
 	IsTop       bool   `json:"is_top"`
-	IsDelete    bool   `json:"is_delete"`
+	IsDelete    bool   `gorm:"index:idx_article_list,priority:1" json:"is_delete"`
 	OriginalUrl string `json:"original_url"`
 
-	CategoryId int `json:"category_id"`
-	UserId     int `json:"-"` // user_auth_id
+	CategoryId int `gorm:"index:idx_article_category" json:"category_id"`
+	UserId     int `gorm:"index:idx_article_user" json:"-"` // user_auth_id
 
 	Tags     []*Tag    `gorm:"many2many:article_tag;joinForeignKey:article_id" json:"tags"`
 	Category *Category `gorm:"foreignkey:CategoryId" json:"category"`
@@ -43,6 +43,7 @@ type Article struct {
 }
 
 type ArticleTag struct {
+	// gorm 依据 many2many 自建这张表, 主键就是 (tag_id, article_id), 已经带索引
 	ArticleId int
 	TagId     int
 }

--- a/gin-blog-server/internal/model/article_query_test.go
+++ b/gin-blog-server/internal/model/article_query_test.go
@@ -185,6 +185,26 @@ func TestDeleteArticleRemovesComments(t *testing.T) {
 		"其他文章的评论和友链留言不受影响")
 }
 
+// 迁移要真的把热点查询的索引建出来, 漏掉就是全表扫描
+func TestHotQueryIndexesCreated(t *testing.T) {
+	db := newModelDB(t)
+	m := db.Migrator()
+
+	cases := []struct {
+		model any
+		index string
+	}{
+		{&Article{}, "idx_article_list"},     // is_delete + status
+		{&Article{}, "idx_article_category"}, // 按分类筛选
+		{&Comment{}, "idx_comment_topic"},    // type + topic_id
+		{&Comment{}, "idx_comment_parent"},   // 查回复
+		{&Resource{}, "idx_resource_api"},    // url + method, 每个请求都要查
+	}
+	for _, c := range cases {
+		assert.True(t, m.HasIndex(c.model, c.index), "缺少索引: "+c.index)
+	}
+}
+
 // 导入 markdown: 分类和标签不存在时自动创建
 func TestImportArticle(t *testing.T) {
 	db := newModelDB(t)

--- a/gin-blog-server/internal/model/auth.go
+++ b/gin-blog-server/internal/model/auth.go
@@ -47,8 +47,8 @@ type Resource struct {
 	Model
 	Name      string `gorm:"unique;type:varchar(50)" json:"name"`
 	ParentId  int    `json:"parent_id"`
-	Url       string `gorm:"type:varchar(255)" json:"url"`
-	Method    string `gorm:"type:varchar(10)" json:"request_method"`
+	Url       string `gorm:"type:varchar(255);index:idx_resource_api,priority:1" json:"url"`
+	Method    string `gorm:"type:varchar(10);index:idx_resource_api,priority:2" json:"request_method"`
 	Anonymous bool   `json:"is_anonymous"`
 
 	Roles []*Role `json:"roles" gorm:"many2many:role_resource"`

--- a/gin-blog-server/internal/model/comment.go
+++ b/gin-blog-server/internal/model/comment.go
@@ -17,12 +17,12 @@ const (
 
 type Comment struct {
 	Model
-	UserId      int    `json:"user_id"`       // 评论者
-	ReplyUserId int    `json:"reply_user_id"` // 被回复者
-	TopicId     int    `json:"topic_id"`      // 评论的文章
-	ParentId    int    `json:"parent_id"`     // 父评论 被回复的评论
+	UserId      int    `gorm:"index:idx_comment_user" json:"user_id"`              // 评论者
+	ReplyUserId int    `json:"reply_user_id"`                                      // 被回复者
+	TopicId     int    `gorm:"index:idx_comment_topic,priority:2" json:"topic_id"` // 评论的文章
+	ParentId    int    `gorm:"index:idx_comment_parent" json:"parent_id"`          // 父评论 被回复的评论
 	Content     string `gorm:"type:varchar(500);not null" json:"content"`
-	Type        int    `gorm:"type:tinyint(1);not null;comment:评论类型(1.文章 2.友链 3.说说)" json:"type"` // 评论类型 1.文章 2.友链 3.说说
+	Type        int    `gorm:"type:tinyint(1);not null;index:idx_comment_topic,priority:1;comment:评论类型(1.文章 2.友链 3.说说)" json:"type"` // 评论类型 1.文章 2.友链 3.说说
 	IsReview    bool   `json:"is_review"`
 
 	// Belongs To
@@ -104,45 +104,69 @@ func GetCommentList(db *gorm.DB, page, size, typ int, isReview *bool, nickname s
 	return data, total, result.Error
 }
 
-// 获取博客评论列表
+// 获取博客评论列表: 顶级评论分页, 每条评论带上它的回复
+// 只返回审核通过的, 未审核的不能出现在前台(GetArticleCommentCount 也是按 is_review 统计的)
 func GetCommentVOList(db *gorm.DB, page, size, topic, typ int) (data []CommentVO, total int64, err error) {
-	var list []Comment
-
-	tx := db.Model(&Comment{})
-	if typ != 0 {
-		tx = tx.Where("type = ?", typ)
+	// 过滤条件写成 scope, Count 和 Find 各用一次全新的查询,
+	// 之前把 Preload / Scopes(Paginate) 的返回值丢掉了(链式调用返回的是新对象),
+	// 导致分页参数完全没生效, 每次都把所有顶级评论返回给前台
+	filter := func(d *gorm.DB) *gorm.DB {
+		d = d.Where("parent_id = 0 AND is_review = ?", true)
+		if typ != 0 {
+			d = d.Where("type = ?", typ)
+		}
+		if topic != 0 {
+			d = d.Where("topic_id = ?", topic)
+		}
+		return d
 	}
-	if topic != 0 {
-		tx = tx.Where("topic_id = ?", topic)
-	}
 
-	// 获取顶级评论列表
-	tx.Where("parent_id = 0").
-		Count(&total).
-		Preload("User").Preload("User.UserInfo").
-		// Preload("ReplyUser").Preload("ReplyUser.UserInfo").
-		Order("id DESC").
-		Scopes(Paginate(page, size))
-	if err := tx.Find(&list).Error; err != nil {
+	if err := db.Model(&Comment{}).Scopes(filter).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
 
-	// 获取顶级评论的回复列表
+	var list []Comment
+	if err := db.Model(&Comment{}).Scopes(filter).
+		Preload("User").Preload("User.UserInfo").
+		Order("id DESC").
+		Scopes(Paginate(page, size)).
+		Find(&list).Error; err != nil {
+		return nil, 0, err
+	}
+
+	data = make([]CommentVO, 0, len(list))
+	if len(list) == 0 {
+		return data, total, nil
+	}
+
+	// 一次把本页所有顶级评论的回复查回来, 而不是每条评论查一次(N+1)
+	ids := make([]int, 0, len(list))
 	for _, v := range list {
-		replyList := make([]CommentVO, 0)
+		ids = append(ids, v.ID)
+	}
 
-		tx := db.Model(&Comment{})
-		tx.Where("parent_id = ?", v.ID).
-			Preload("User").Preload("User.UserInfo").
-			// Preload("ReplyUser").Preload("ReplyUser.UserInfo")
-			Order("id DESC")
-		if err := tx.Find(&replyList).Error; err != nil {
-			return nil, 0, err
+	var replies []Comment
+	if err := db.Model(&Comment{}).
+		Where("parent_id IN ? AND is_review = ?", ids, true).
+		Preload("User").Preload("User.UserInfo").
+		Order("id DESC").
+		Find(&replies).Error; err != nil {
+		return nil, 0, err
+	}
+
+	grouped := make(map[int][]CommentVO, len(ids))
+	for _, reply := range replies {
+		grouped[reply.ParentId] = append(grouped[reply.ParentId], CommentVO{Comment: reply})
+	}
+
+	for _, v := range list {
+		replyList := grouped[v.ID]
+		if replyList == nil {
+			replyList = make([]CommentVO, 0)
 		}
-
 		data = append(data, CommentVO{
-			ReplyCount: len(replyList),
 			Comment:    v,
+			ReplyCount: len(replyList),
 			ReplyList:  replyList,
 		})
 	}
@@ -150,10 +174,10 @@ func GetCommentVOList(db *gorm.DB, page, size, topic, typ int) (data []CommentVO
 	return data, total, nil
 }
 
-// 根据 [评论id] 获取 [回复列表]
+// 根据 [评论id] 获取 [回复列表], 同样只返回审核通过的
 func GetCommentReplyList(db *gorm.DB, id, page, size int) (data []Comment, err error) {
 	result := db.Model(&Comment{}).
-		Where(&Comment{ParentId: id}).
+		Where("parent_id = ? AND is_review = ?", id, true).
 		Preload("User").Preload("User.UserInfo").
 		Order("id DESC").
 		Scopes(Paginate(page, size)).

--- a/gin-blog-server/internal/model/comment_test.go
+++ b/gin-blog-server/internal/model/comment_test.go
@@ -60,3 +60,92 @@ func TestGetCommentList(t *testing.T) {
 	assert.Equal(t, "nickname", v1.ReplyUser.UserInfo.Nickname) // preload replyUser.userInfo
 	assert.Equal(t, "title", v1.Article.Title)                  // preload article
 }
+
+// 前台评论列表: 顶级评论分页生效, 回复一次查回并按父评论分组
+func TestGetCommentVOList(t *testing.T) {
+	db := newModelDB(t)
+
+	user := UserAuth{Username: "username", Password: "123456", UserInfo: &UserInfo{Nickname: "nickname"}}
+	assert.Nil(t, db.Create(&user).Error)
+	article := Article{Title: "title"}
+	assert.Nil(t, db.Create(&article).Error)
+	other := Article{Title: "other"}
+	assert.Nil(t, db.Create(&other).Error)
+
+	// 3 条顶级评论, 其中第一条有 2 条回复
+	first, err := AddComment(db, user.ID, TYPE_ARTICLE, article.ID, "第一条", true)
+	assert.Nil(t, err)
+	_, err = AddComment(db, user.ID, TYPE_ARTICLE, article.ID, "第二条", true)
+	assert.Nil(t, err)
+	_, err = AddComment(db, user.ID, TYPE_ARTICLE, article.ID, "第三条", true)
+	assert.Nil(t, err)
+	_, err = ReplyComment(db, user.ID, user.ID, first.ID, "回复一", true)
+	assert.Nil(t, err)
+	_, err = ReplyComment(db, user.ID, user.ID, first.ID, "回复二", true)
+	assert.Nil(t, err)
+	// 其他文章的评论不能混进来
+	_, err = AddComment(db, user.ID, TYPE_ARTICLE, other.ID, "别人的", true)
+	assert.Nil(t, err)
+
+	// 分页只返回 2 条顶级评论, total 是顶级评论总数(不含回复)
+	data, total, err := GetCommentVOList(db, 1, 2, article.ID, TYPE_ARTICLE)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(3), total)
+	assert.Len(t, data, 2, "分页参数要生效")
+	assert.Equal(t, "第三条", data[0].Content, "按 id 倒序")
+
+	// 第二页
+	data, _, err = GetCommentVOList(db, 2, 2, article.ID, TYPE_ARTICLE)
+	assert.Nil(t, err)
+	assert.Len(t, data, 1)
+	assert.Equal(t, "第一条", data[0].Content)
+	assert.Equal(t, 2, data[0].ReplyCount)
+	assert.Len(t, data[0].ReplyList, 2)
+	assert.Equal(t, "回复二", data[0].ReplyList[0].Content, "回复也按 id 倒序")
+	assert.Equal(t, "nickname", data[0].ReplyList[0].User.UserInfo.Nickname, "回复要预加载用户")
+
+	// 没有回复的评论给空数组而不是 nil, 前端可以直接遍历
+	data, _, err = GetCommentVOList(db, 1, 1, article.ID, TYPE_ARTICLE)
+	assert.Nil(t, err)
+	assert.NotNil(t, data[0].ReplyList)
+	assert.Empty(t, data[0].ReplyList)
+}
+
+// 未审核的评论和回复都不能出现在前台
+func TestGetCommentVOListOnlyReviewed(t *testing.T) {
+	db := newModelDB(t)
+
+	user := UserAuth{Username: "username", Password: "123456", UserInfo: &UserInfo{Nickname: "nickname"}}
+	assert.Nil(t, db.Create(&user).Error)
+	article := Article{Title: "title"}
+	assert.Nil(t, db.Create(&article).Error)
+
+	reviewed, err := AddComment(db, user.ID, TYPE_ARTICLE, article.ID, "已审核", true)
+	assert.Nil(t, err)
+	_, err = AddComment(db, user.ID, TYPE_ARTICLE, article.ID, "待审核", false)
+	assert.Nil(t, err)
+	_, err = ReplyComment(db, user.ID, user.ID, reviewed.ID, "已审核的回复", true)
+	assert.Nil(t, err)
+	_, err = ReplyComment(db, user.ID, user.ID, reviewed.ID, "待审核的回复", false)
+	assert.Nil(t, err)
+
+	data, total, err := GetCommentVOList(db, 1, 10, article.ID, TYPE_ARTICLE)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), total, "total 不能把未审核的算进去")
+	assert.Len(t, data, 1)
+	assert.Equal(t, "已审核", data[0].Content)
+	assert.Equal(t, 1, data[0].ReplyCount)
+	assert.Len(t, data[0].ReplyList, 1)
+	assert.Equal(t, "已审核的回复", data[0].ReplyList[0].Content)
+
+	// 展示条数要和文章评论数(同样按 is_review 统计)对得上
+	count, err := GetArticleCommentCount(db, article.ID)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(2), count, "已审核的顶级评论 + 回复")
+
+	// 单独分页拉回复时也要过滤
+	replies, err := GetCommentReplyList(db, reviewed.ID, 1, 10)
+	assert.Nil(t, err)
+	assert.Len(t, replies, 1)
+	assert.Equal(t, "已审核的回复", replies[0].Content)
+}

--- a/gin-blog-server/internal/utils/ip.go
+++ b/gin-blog-server/internal/utils/ip.go
@@ -2,10 +2,10 @@ package utils
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
 	"net"
 	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/lionsoul2014/ip2region/binding/golang/xdb"
@@ -70,27 +70,42 @@ func (*ipUtil) GetIpAddress(c *gin.Context) (ipAddress string) {
 
 // 获取 IP 来源
 // https://github.com/lionsoul2014/ip2region
-var vIndex []byte // 缓存 VectorIndex 索引, 减少一次固定的 IO 操作
+const xdbPath = "../assets/ip2region.xdb" // IP 数据库文件, 路径相对于 main.go
+
+var (
+	xdbOnce    sync.Once
+	xdbContent []byte
+	xdbErr     error
+)
+
+/*
+第一次用到时把整个 xdb(约 11MB) 读进内存并复用
+
+之前每次查询都要重新打开文件、构造 searcher, 而访客上报和登录都会走到这里。
+用内存缓存换掉这部分 IO, 代价是常驻内存多 11MB, 且只在真正查过 IP 后才占用。
+*/
+func loadXdbContent() ([]byte, error) {
+	xdbOnce.Do(func() {
+		xdbContent, xdbErr = xdb.LoadContentFromFile(xdbPath)
+		if xdbErr != nil {
+			slog.Error("加载 IP 数据库失败", "path", xdbPath, "err", xdbErr)
+		}
+	})
+	return xdbContent, xdbErr
+}
 
 // 获取地域信息: 中国|0|江苏省|苏州市|电信
 func (*ipUtil) GetIpSource(ipAddress string) string {
-	var dbPath = "../assets/ip2region.xdb" // IP 数据库文件
-	// 完全基于文件查询, 每次都读取文件
-	// searcher, err := xdb.NewWithFileOnly(dbPath)
-
-	// 缓存 VectorIndex 索引, 减少一次固定的 IO 操作
-	if vIndex == nil {
-		var err error
-		vIndex, err = xdb.LoadVectorIndexFromFile(dbPath)
-		if err != nil {
-			slog.Error(fmt.Sprintf("failed to load vector index from `%s`: %s\n", dbPath, err))
-			return ""
-		}
-	}
-	searcher, err := xdb.NewWithVectorIndex(dbPath, vIndex)
-
+	content, err := loadXdbContent()
 	if err != nil {
-		slog.Error("failed to create searcher with vector index", "err", err)
+		return ""
+	}
+
+	// searcher 只是包了一层 buffer, 构造过程没有 IO;
+	// 但它本身不是并发安全的, 所以不共享, 每次查询新建一个
+	searcher, err := xdb.NewWithBuffer(content)
+	if err != nil {
+		slog.Error("创建 IP 查询器失败", "err", err)
 		return ""
 	}
 	defer searcher.Close()
@@ -99,7 +114,7 @@ func (*ipUtil) GetIpSource(ipAddress string) string {
 	// 只有中国的数据绝大部分精确到了城市, 其他国家部分数据只能定位到国家, 后面的选项全部是 0
 	region, err := searcher.SearchByStr(ipAddress)
 	if err != nil {
-		slog.Error(fmt.Sprintf("failed to search ip(%s): %s\n", ipAddress, err))
+		slog.Error("查询 IP 归属失败", "ip", ipAddress, "err", err)
 		return ""
 	}
 	return region


### PR DESCRIPTION
- article/comment/resource 补联合索引, 并加测试断言迁移真的建出来
- GetCommentVOList 修复 Preload/分页返回值被丢弃导致的分页失效, 回复改为一次查回
- 列表接口的点赞数/浏览量改用 HMGet/ZMScore 按当页 id 取, 不再全量拉取
- IP 归属查询复用内存中的 xdb, 不再每次重开文件
- 前台不再展示未审核的评论与回复, 与 GetArticleCommentCount 口径一致
- 留言读自己的审核开关 is_message_review, 而不是评论的

Change-Id: I28b7bca014c73773502d0802ef0e26aa806077cc